### PR TITLE
Add support for macOS on Apple Silicon.

### DIFF
--- a/src/fiber_asm_aarch64_apcs.S
+++ b/src/fiber_asm_aarch64_apcs.S
@@ -2,14 +2,15 @@
   .arch armv8-a
   .text
 
-#define FUNC(sym) \
-  .align 4; \
-  .global sym; \
-  .hidden sym; \
-  .type sym, @function; \
-  sym
+#include <hu/objfmt.h>
 
+#if HU_OBJFMT_ELF_P
 #define END_FUNC(sym) .size sym, .-sym
+#elif HU_OBJFMT_MACHO_P
+#define END_FUNC(sym)
+#else
+#error "HU_OBJFMT_*_P neither ELF nor MACHO"
+#endif
 
   .macro check_stack_alignment_nomove reg
 #ifdef FIBER_ASM_CHECK_ALIGNMENT
@@ -25,7 +26,17 @@
 #endif
   .endm
 
-FUNC(fiber_asm_switch):
+#if HU_OBJFMT_ELF_P
+  .align 4
+  .global fiber_asm_switch
+  .hidden fiber_asm_switch
+  .type fiber_asm_switch, @function
+  fiber_asm_switch:
+#elif HU_OBJFMT_MACHO_P
+  .align 4
+  .global _fiber_asm_switch
+  _fiber_asm_switch:
+#endif
   mov x3, sp
   str x3, [x0], 8
   ldr x3, [x1], 8
@@ -57,7 +68,17 @@ FUNC(fiber_asm_switch):
   ret
 END_FUNC(fiber_asm_switch)
 
-FUNC(fiber_asm_invoke):
+#if HU_OBJFMT_ELF_P
+  .align 4
+  .global fiber_asm_invoke
+  .hidden fiber_asm_invoke
+  .type fiber_asm_invoke, @function
+  fiber_asm_invoke:
+#elif HU_OBJFMT_MACHO_P
+  .align 4
+  .global _fiber_asm_invoke
+  _fiber_asm_invoke:
+#endif
   ldp x0, x1, [sp], 16
   check_stack_alignment_move x3
   blr x1
@@ -67,7 +88,17 @@ FUNC(fiber_asm_invoke):
   ret
 END_FUNC(fiber_asm_invoke)
 
-FUNC(fiber_asm_exec_on_stack):
+#if HU_OBJFMT_ELF_P
+  .align 4
+  .global fiber_asm_exec_on_stack
+  .hidden fiber_asm_exec_on_stack
+  .type fiber_asm_exec_on_stack, @function
+  fiber_asm_exec_on_stack:
+#elif HU_OBJFMT_MACHO_P
+  .align 4
+  .global _fiber_asm_exec_on_stack
+  _fiber_asm_exec_on_stack:
+#endif
   mov x3, sp
   stp x3, lr, [x2, #-16]!
   mov sp, x2
@@ -80,5 +111,9 @@ END_FUNC(fiber_asm_exec_on_stack)
 
 #ifdef FIBER_ASM_CHECK_ALIGNMENT
 align_check_failed:
+#if HU_OBJFMT_ELF_P
   b fiber_align_check_failed
+#elif HU_OBJFMT_MACHO_P
+  b _fiber_align_check_failed
+#endif
 #endif


### PR DESCRIPTION
I tweaked the ARM assembly code along the lines of what the x86 code
is already doing for Mach-O. However, I had to roll out one of the C
preprocessor macros because I couldn't get semicolon-separated
directives to work; newlines seem required. There may be better ways
to do this.

Note: I don't have a system to confirm that I didn't break the existing
support ARM on ELF ...